### PR TITLE
修正自由時報時尚版關鍵字抓取

### DIFF
--- a/floodfire_crawler/engine/ltn_page_crawler.py
+++ b/floodfire_crawler/engine/ltn_page_crawler.py
@@ -234,10 +234,12 @@ class LtnPageCrawler(BasePageCrawler):
         page['publish_time'] = strftime('%Y-%m-%d %H:%M:%S', strptime(time_string, '%b. %d %Y %H:%M:%S'))
         
         # --- 取出關鍵字 ---
+        # 2018-11-13 發現時尚網頁改版，沒有關鍵字區段
         page['keywords'] = list()
-        keywords = soup.find('article').find('section', class_='tag boxTitle').find_all('a')
-        for keyword in keywords:
-            page['keywords'].append(keyword.text.strip())
+        if soup.find('article').find('section', class_='tag boxTitle'):
+            keywords = soup.find('article').find('section', class_='tag boxTitle').find_all('a')
+            for keyword in keywords:
+                page['keywords'].append(keyword.text.strip())
         
         # -- 取出記者 ---
         author = article_title.find('p', class_='auther').find('span').text.strip()


### PR DESCRIPTION
自由時報時尚版網頁改版，新版網頁沒有關鍵字欄位。增加檢查語法，當沒
有關鍵字區塊時回傳空 list