### PR TITLE
新增爬抓List的類別限制：apd, ett, udn

### DIFF
--- a/floodfire_crawler/engine/apd_list_crawler.py
+++ b/floodfire_crawler/engine/apd_list_crawler.py
@@ -49,12 +49,14 @@ class ApdListCrawler(BaseListCrawler):
                 'url': link_a['href'],
                 'url_md5': md5hash,
                 'source_id': 1,
-                'category': link_a.h2.text
+                'category': link_a.h2.text.strip().replace("　"," ").replace("\u200b","")
             }
             news.append(raw)
         return news
 
     def make_a_round(self):
+        filter = ['財經', '政治', '社會', '生活', '娛樂', '國際', '體育', '論壇']
+
         consecutive = 0
         start_page = 1
         page = 1
@@ -75,7 +77,7 @@ class ApdListCrawler(BaseListCrawler):
             news_list = self.fetch_list(soup)
             #print(news_list)
             for news in news_list:
-                if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+                if(self.floodfire_storage.check_list(news['url_md5']) == 0 and news['category'] in filter):
                     self.floodfire_storage.insert_list(news)
                     consecutive = 0
                 else:
@@ -85,19 +87,4 @@ class ApdListCrawler(BaseListCrawler):
 
 
     def run(self):
-        html = self.fetch_html(self.url)
-        soup = BeautifulSoup(html, 'html.parser')
         self.make_a_round()
-        """
-        news_list = self.fetch_list(soup)
-        print(news_list)
-        for news in news_list:
-            if(self.floodfire_storage.check_list(news['url_md5']) == 0):
-                self.floodfire_storage.insert_list(news)
-            else:
-                print(news['title']+' exist! skip insert.')
-            
-        last_page = self.get_last(soup)
-        print(last_page)
-        """
-        

--- a/floodfire_crawler/engine/ett_list_crawler.py
+++ b/floodfire_crawler/engine/ett_list_crawler.py
@@ -62,13 +62,15 @@ class EttListCrawler(BaseListCrawler):
                 'url': "https://www.ettoday.net"+link_a['href'].split("?")[0],
                 'url_md5': md5hash,
                 'source_id': 4,
-                'category': news_row.em.text
+                'category': news_row.em.text.strip().replace("　"," ").replace("\u200b","")
             }
             news.append(raw)
         return news
 
 
     def make_a_round(self):
+        filter = ['政治', '地方', '影劇', '國際', '財經', '生活', '社會', '大陸', '體育', '論壇', '軍武']
+
         #first page
         consecutive = 0
         page_url = self.url
@@ -80,7 +82,7 @@ class EttListCrawler(BaseListCrawler):
         news_list = self.fetch_list(soup)
         #print(news_list)
         for news in news_list:
-            if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+            if(self.floodfire_storage.check_list(news['url_md5']) == 0 and news['category'] in filter):
                 self.floodfire_storage.insert_list(news)
                 consecutive = 0
             else:
@@ -122,7 +124,7 @@ class EttListCrawler(BaseListCrawler):
             news_list = self.fetch_list2(soup)
             #print(news_list)
             for news in news_list:
-                if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+                if(self.floodfire_storage.check_list(news['url_md5']) == 0 and news['category'] in filter):
                     self.floodfire_storage.insert_list(news)
                     consecutive = 0
                 else:
@@ -132,16 +134,3 @@ class EttListCrawler(BaseListCrawler):
 
     def run(self):
         self.make_a_round()
-        """
-        news_list = self.fetch_list(soup)
-        print(news_list)
-        for news in news_list:
-            if(self.floodfire_storage.check_list(news['url_md5']) == 0):
-                self.floodfire_storage.insert_list(news)
-            else:
-                print(news['title']+' exist! skip insert.')
-            
-        last_page = self.get_last(soup)
-        print(last_page)
-        """
-        

--- a/floodfire_crawler/engine/udn_list_crawler.py
+++ b/floodfire_crawler/engine/udn_list_crawler.py
@@ -45,12 +45,14 @@ class UdnListCrawler(BaseListCrawler):
                 'url': "https://udn.com"+link_a['href'].split("?")[0],
                 'url_md5': md5hash,
                 'source_id': 8,
-                'category': news_row.find_all("a")[-2].text
+                'category': news_row.find_all("a")[-2].text.strip().replace("　"," ").replace("\u200b","")
             }
             news.append(raw)
         return news
 
     def make_a_round(self):
+        filter = ['社會', '生活', '地方', '全球', '要聞', '文教', '產經', '兩岸', '運動', '股市', '評論', '娛樂']
+
         #first page
         consecutive = 0
         page_url = self.url
@@ -64,7 +66,7 @@ class UdnListCrawler(BaseListCrawler):
         news_list = self.fetch_list(soup)
         #print(news_list)
         for news in news_list:
-            if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+            if(self.floodfire_storage.check_list(news['url_md5']) == 0 and news['category'] in filter):
                 self.floodfire_storage.insert_list(news)
                 consecutive = 0
             else:
@@ -86,7 +88,7 @@ class UdnListCrawler(BaseListCrawler):
             news_list = self.fetch_list(soup)
             #print(news_list)
             for news in news_list:
-                if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+                if(self.floodfire_storage.check_list(news['url_md5']) == 0 and news['category'] in filter):
                     self.floodfire_storage.insert_list(news)
                     consecutive = 0
                 else:
@@ -97,16 +99,3 @@ class UdnListCrawler(BaseListCrawler):
 
     def run(self):
         self.make_a_round()
-        """
-        news_list = self.fetch_list(soup)
-        print(news_list)
-        for news in news_list:
-            if(self.floodfire_storage.check_list(news['url_md5']) == 0):
-                self.floodfire_storage.insert_list(news)
-            else:
-                print(news['title']+' exist! skip insert.')
-            
-        last_page = self.get_last(soup)
-        print(last_page)
-        """
-        


### PR DESCRIPTION
新增蘋果日報、ETtoday、聯合新聞網爬抓List後存入的限制
以往需要滿足一個條件：沒有重複，此次需要滿足兩個條件：沒有重複，且在規定類別