### PR TITLE
修正蘋果日報作者問題、中時電子報改版、自由時報相關影音空行問題

### DIFF
--- a/_INSTALL/ffnewsdiff.sql
+++ b/_INSTALL/ffnewsdiff.sql
@@ -97,8 +97,8 @@ CREATE TABLE `source` (
 
 INSERT INTO `source` (`id`, `code_name`, `media_name`, `note`) VALUES
 (1, 'apd', '蘋果日報', ''),
-(2, '', '中時電子報', ''),
-(3, '', '中央社', ''),
+(2, 'cnt', '中時電子報', ''),
+(3, 'cna', '中央社', ''),
 (4, 'ett', '東森新聞', ''),
 (5, 'ltn', '自由時報', ''),
 (6, '', '新頭穀', ''),

--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -73,7 +73,7 @@ class ApdPageCrawler(BasePageCrawler):
         #authors
         brackets = re.findall('(?:（|\()(.*?)(?:）|\))', news_content)
         split_publishers = re.findall("\w+",(', '.join([bracket for bracket in brackets if bracket.find("報導") > 0])))
-        publishers = list(set([x for x in split_publishers if len(re.findall("報導",x))==0]))
+        publishers = list(sorted(set([x for x in split_publishers if len(re.findall("報導",x))==0])))
         page['authors'] = publishers
         
         # --- 取出圖片數 ---

--- a/floodfire_crawler/engine/cnt_list_crawler.py
+++ b/floodfire_crawler/engine/cnt_list_crawler.py
@@ -46,9 +46,11 @@ class CntListCrawler(BaseListCrawler):
         傳回 HTML 中所有的新聞 List
         """
         news = []
-        news_rows = soup.find('article').find('div', class_='listRight').find_all('li', class_='clear-fix')
+        news_rows = soup.find('section', class_='article-list').find_all('li')
         for news_row in news_rows:
-            link_title = news_row.find('h2')
+            link_title = news_row.find('h3')
+            if(news_row.find('h3') is None):
+                continue
             link_a = link_title.find('a')
             link_url = urljoin(self.url, link_a['href'])
             md5hash = md5(link_url.encode('utf-8')).hexdigest()
@@ -67,19 +69,10 @@ class CntListCrawler(BaseListCrawler):
         取得新聞分類
         """
         cate_list = []
-        categories = news_row.find('div', class_='kindOf').find_all('a')
+        categories = news_row.find('div', class_='category').find_all('a')
         for category in categories:
             cate_list.append(category.text.strip())
         return ','.join(cate_list)
-
-    def get_last(self, soup):
-        """
-        取得頁面中的最後一頁
-        """
-        pagination_a_tag = soup.find('div', class_='pagination').find_all('a')
-        href_uri = pagination_a_tag[-1]['href']
-        last_page = href_uri.rsplit('=', 1)[-1]
-        return int(last_page)
 
     def make_a_round(self, start_page, end_page):
         """
@@ -119,5 +112,5 @@ class CntListCrawler(BaseListCrawler):
         if status_code == requests.codes.ok:
             soup = BeautifulSoup(html_content, 'html.parser')
             # print(self.fetch_list(soup))
-            last_page = self.get_last(soup)
+            last_page = 10
             self.make_a_round(1, last_page)

--- a/floodfire_crawler/engine/ltn_page_crawler.py
+++ b/floodfire_crawler/engine/ltn_page_crawler.py
@@ -55,7 +55,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = soup.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article_content.find('span', class_='viewtime').text + ':00'
         
         # 英文新聞中沒有關鍵字區塊
@@ -96,7 +96,7 @@ class LtnPageCrawler(BasePageCrawler):
         article = soup.find('div', itemprop='articleBody')
         page['title'] = article.h1.text.strip()
         p_tags = article.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         time_string = soup.find('meta', attrs={'name':'pubdate'})
         page['publish_time'] = strftime('%Y-%m-%d %H:%M:%S', strptime(time_string['content'][:-6], '%Y-%m-%dT%H:%M:%S'))
 
@@ -137,7 +137,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = article.find('div', class_='text')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article.find('span', class_='time').text + ':00'
 
         # --- 取出關鍵字 ---
@@ -179,7 +179,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = article.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article.find('div', class_='c_time').text + ':00'
 
         # --- 取出關鍵字 ---
@@ -221,7 +221,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = article.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         
         # 有無作者資訊會影響出現的時間區段
         if article.find('div', class_='mobile_none'):
@@ -271,7 +271,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article_title.h2.text.strip()
         article_content = soup.find('article').find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         
         time_string = article_title.find('div', class_='label-date').text
         page['publish_time'] = strftime('%Y-%m-%d %H:%M:%S', strptime(time_string, '%b. %d %Y %H:%M:%S'))
@@ -317,7 +317,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = article.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] =  article.find('div', class_='writer').select('span')[1].text + ':00'
         
         # --- 取出關鍵字 ---
@@ -361,7 +361,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.find('div', class_='boxText').text.strip()
         article_content = article.find('div', class_='text')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article_content.find('span', class_='date1').text
         return page
 
@@ -374,7 +374,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article_title.text.strip()
         article_content = soup.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article_content.find('span', class_='h1dt').text + ':00'
 
         # --- 取出關鍵字 ---
@@ -418,7 +418,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article_title.h1.text.strip()
         article_content = soup.find('div', itemprop='articleBody').find('div', class_='text')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text.strip() for p in p_tags])
+        page['body'] = "\n".join([p.text.strip() for p in p_tags if len(p.text) > 0])
         time_string = soup.find('meta', property='article:published_time')
         page['publish_time'] = strftime('%Y-%m-%d %H:%M:%S', strptime(time_string['content'][:-7], '%Y-%m-%dT%H:%M:%S'))
         
@@ -465,7 +465,7 @@ class LtnPageCrawler(BasePageCrawler):
         page['title'] = article.h1.text.strip()
         article_content = soup.find('div', itemprop='articleBody')
         p_tags = article_content.find_all('p',recursive=False)
-        page['body'] = "\n".join([p.text for p in p_tags])
+        page['body'] = "\n".join([p.text for p in p_tags if len(p.text) > 0])
         page['publish_time'] = article_content.find_all('span')[0].text + ':00'
 
         # --- 取出關鍵字 ---


### PR DESCRIPTION
蘋果日報作者由於使用set()，hash的seed會隨每次爬抓不同，因此順序會調換，加上sorted解決
中時作者欄位會因為if導致沒有cite tag的作者不會選入，修正完試爬發現網頁大改版，所以更新爬抓
自由時報內文會因為相關影音導致多空一行，因此改寫如果該行只有空字串則刪除(所有版別都加上該判斷)