### PR TITLE
因應自由時報改版修正，刪除聯合新聞遺留測資

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -38,7 +38,7 @@ class Crawler():
         """
         if self.args.typeof == 'list':
             llc = LtnListCrawler(self.config)
-            llc.url = 'https://news.ltn.com.tw/list/breakingnews'
+            llc.url = 'https://news.ltn.com.tw/ajax/breakingnews/all/'
             llc.run()
 
         elif self.args.typeof == 'page':

--- a/floodfire_crawler/engine/ltn_list_crawler.py
+++ b/floodfire_crawler/engine/ltn_list_crawler.py
@@ -7,6 +7,7 @@ from time import sleep
 from urllib.parse import urljoin
 from floodfire_crawler.core.base_list_crawler import BaseListCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+import json
 
 class LtnListCrawler(BaseListCrawler):
 
@@ -46,45 +47,29 @@ class LtnListCrawler(BaseListCrawler):
         傳回 HTML 中所有的新聞 List
         """
         news = []
-        news_rows = soup.find('ul', 'imm').find_all('li')
-        #md5hash = md5()
+        news_rows = json.loads(soup.text)['data']
+        if (type(news_rows) != list):
+            news_rows = list(news_rows.values())
+
+        if len(news_rows) == 0:
+            return news
+        
         for news_row in news_rows:
-            # if news_row.has_attr('id'):
-            #     print('AD')
-            link_a = news_row.find('a', class_='tit')
-            # 20190111 自由時報加入廣告欄位，廣告內容無 a tag
-            if link_a is None:
-                continue
-            md5hash = md5(link_a['href'].encode('utf-8')).hexdigest()
+            md5hash = md5(news_row['url'].encode('utf-8')).hexdigest()
             raw = {
-                'title': link_a.p.text.strip(),
-                'url': urljoin(self._url, link_a['href']),
+                'title': news_row['title'],
+                'url': news_row['url'],
                 'url_md5': md5hash,
                 'source_id': 5,
-                'category': self.get_category(link_a['href'])
+                'category': news_row['type_cn']
             }
             news.append(raw)
         return news
 
     def get_last(self, soup):
-        """
-        取得頁面中的最後一頁
-        """
-        last_a_tag = soup.find('div', class_='pagination').find('a', class_='p_last')
-        href_uri = last_a_tag['href']
-        last_page = href_uri.rsplit('/', 1)[-1]
-        return int(last_page)
+        pass
 
-    def get_category(self, url):
-        """
-        取得新聞分類
-        """
-        if(url.split('/')[2].split('.')[0] != 'news'):
-            return url.split('/')[2].split('.')[0]
-        else:
-            return url.split('/')[4]
-
-    def make_a_round(self, start_page, end_page):
+    def make_a_round(self):
         """
         指定頁面區間抓取
         Keyword arguments:
@@ -92,32 +77,38 @@ class LtnListCrawler(BaseListCrawler):
             end_page (int) -- 結束頁面
         """
         consecutive = 0
-        for page in range(start_page, end_page+1):
-            if consecutive > 20:
-                print('News consecutive more than 20, stop crawler!!')
-                break
-            page_url = self.url + '/all/' + str(page)
+        page_idx = 1
+        url = self.url
+
+        while 1:
+            page_url = url+str(page_idx)
             print(page_url)
             sleep(2)
+
             status_code, html_content = self.fetch_html(page_url)
-
-            if status_code == requests.codes.ok:
-                soup = BeautifulSoup(html_content, 'html.parser')
-                news_list = self.fetch_list(soup)
-                #print(news_list)
-                for news in news_list:
-                    if(self.floodfire_storage.check_list(news['url_md5']) == 0):
-                        self.floodfire_storage.insert_list(news)
-                        consecutive = 0
-                    else:
-                        print(news['title']+' exist! skip insert.')
-                        consecutive += 1
-
+            page_idx+=1
+            if (status_code != 200):
+                break
+            
+            soup = BeautifulSoup(html_content, 'html.parser')
+            news_list = self.fetch_list(soup)
+            if len(news_list) == 0:
+                print('Realtime end.')
+                break
+            print(len(news_list))
+            for news in news_list:
+                if(self.floodfire_storage.check_list(news['url_md5']) == 0):
+                    self.floodfire_storage.insert_list(news)
+                    consecutive = 0
+                else:
+                    print(news['title']+' exist! skip insert.')
+                    consecutive += 1
+                if consecutive > 20:
+#                    print('News consecutive more than 20, stop crawler!!')
+                    break
+            if consecutive > 20:
+                    print('News consecutive more than 20, stop crawler!!')
+                    break
 
     def run(self):
-        status_code, html_content = self.fetch_html(self.url)
-        if status_code == requests.codes.ok:
-            soup = BeautifulSoup(html_content, 'html.parser')
-            last_page = self.get_last(soup)
-            self.make_a_round(1, last_page)
-        
+        self.make_a_round()

--- a/floodfire_crawler/engine/udn_page_crawler.py
+++ b/floodfire_crawler/engine/udn_page_crawler.py
@@ -199,12 +199,10 @@ class UdnPageCrawler(BasePageCrawler):
                 print(row['url'])
                 if status_code == requests.codes.ok:
                     print('crawling... id: {}'.format(row['id']))
-                    if (row['id'] in [703]):
-                        continue
                     soup = BeautifulSoup(html_content['html'], 'html.parser')
                     news_page = self.fetch_news_content(soup)
                     
-                    #miss while redirect
+                    #miss while redirect, put back later
                     publish_time = news_page['publish_time']
 
                     #if there is redirection


### PR DESCRIPTION
自由時報10/24改版，因此修改了list跟page
list : 修改入口頁面，修改下一頁進入點，修改結束條件
page : 修改news, ec, istyle三個版別的取得方法，新增一個partners版

聯合新聞撰寫時的測資忘記刪除，此次更新一並刪除