### PR TITLE
修改變數跟class撞名問題導致的無法執行

### DIFF
--- a/floodfire_crawler/engine/ntk_list_crawler.py
+++ b/floodfire_crawler/engine/ntk_list_crawler.py
@@ -76,11 +76,11 @@ class NtkListCrawler(BaseListCrawler):
                 consecutive += 1
 
         # next page
-        for date in (today - timedelta(days=x) for x in range(numdays)):
+        for mydate in (today - timedelta(days=x) for x in range(numdays)):
             if consecutive > 20:
                 print('News consecutive more than 20, stop crawler!!')
                 break
-            page_url = "https://newtalk.tw/news/summary/" + date.isoformat()
+            page_url = "https://newtalk.tw/news/summary/" + mydate.isoformat()
             print(page_url)
             sleep(2)
             html = self.fetch_html(page_url)

--- a/floodfire_crawler/engine/ntk_page_crawler.py
+++ b/floodfire_crawler/engine/ntk_page_crawler.py
@@ -84,7 +84,6 @@ class NtkPageCrawler(BasePageCrawler):
         # --- 取出影片數 ---
 
         video = soup.find('div', {"itemprop": 'articleBody'}).findAll('p')[-1].find('iframe')
-        print(video)
         if video:
             page['video'] = 1
             # -- 取出視覺資料連結（影片） ---


### PR DESCRIPTION
由於變數名稱date跟class名稱date撞名，因此會無法執行
因此將變數名稱由date修改為mydate，使之可以順利執行

刪除不必要的影片名稱輸出