### PR TITLE
新增其他報紙的Diff機制，部分做了格式調整

### DIFF
--- a/floodfire_crawler/engine/cna_page_crawler.py
+++ b/floodfire_crawler/engine/cna_page_crawler.py
@@ -9,6 +9,7 @@ from time import sleep, strftime, strptime
 from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+from floodfire_crawler.service.diff import FloodfireDiff
 
 class CnaPageCrawler(BasePageCrawler):
 
@@ -204,7 +205,16 @@ class CnaPageCrawler(BasePageCrawler):
         """
         # crawl_category = ['news', 'ent', 'ec', 'sports']
         source_id = self.floodfire_storage.get_source_id(self.code_name)
-        crawl_list = self.floodfire_storage.get_crawllist(source_id)
+        ######Diff#######
+        if page_diff:
+            diff_obj = FloodfireDiff()
+        else:
+            diff_obj = None
+        version = 1
+        table_name = None
+        diff_vals = (version, None, None)
+        ######Diff#######
+        crawl_list = self.floodfire_storage.get_crawllist(source_id, page_diff, diff_obj)
         # log 起始訊息
         start_msg = 'Start crawling ' + str(len(crawl_list)) + ' ' + self.code_name + '-news lists.'
         if page_raw:
@@ -241,9 +251,31 @@ class CnaPageCrawler(BasePageCrawler):
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
                     
-                    if self.floodfire_storage.insert_page(news_page):
+                    ######Diff#######
+                    if page_diff:
+                        last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
+                                                                                     news_page['publish_time'],
+                                                                                     diff_obj.compared_cols)
+                        if last_page != None:
+                            diff_col_list = diff_obj.page_diff(news_page, last_page)
+                            if diff_col_list is None:
+                                # 有上一筆，但沒有不同，更新爬抓次數，不儲存
+                                print('has last, no diff')
+                                crawl_count += 1 
+                                self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                                continue
+                            else:
+                                # 出現Diff，儲存
+                                version = last_page['version'] + 1
+                                last_page_id = last_page['id']
+                                diff_cols = ','.join(diff_col_list)
+                                diff_vals = (version, last_page_id, diff_cols)
+                    ######Diff#######
+                    print(diff_vals)
+                    if self.floodfire_storage.insert_page(news_page, table_name, diff_vals):
                         # 更新爬抓次數記錄
                         self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                        self.floodfire_storage.update_list_versioncount(row['url_md5'])
                         # 本次爬抓計數+1
                         crawl_count += 1
                     else:
@@ -255,7 +287,7 @@ class CnaPageCrawler(BasePageCrawler):
                         for vistual_row in news_page['visual_contents']:
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
-                            self.floodfire_storage.insert_visual_link(vistual_row)
+                            self.floodfire_storage.insert_visual_link(vistual_row, version)
                     
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))

--- a/floodfire_crawler/engine/cnt_page_crawler.py
+++ b/floodfire_crawler/engine/cnt_page_crawler.py
@@ -9,6 +9,7 @@ from time import sleep, strftime, strptime
 from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+from floodfire_crawler.service.diff import FloodfireDiff
 
 class CntPageCrawler(BasePageCrawler):
     
@@ -133,7 +134,16 @@ class CntPageCrawler(BasePageCrawler):
         程式進入點
         """
         source_id = self.floodfire_storage.get_source_id(self.code_name)
-        crawl_list = self.floodfire_storage.get_crawllist(source_id)
+        ######Diff#######
+        if page_diff:
+            diff_obj = FloodfireDiff()
+        else:
+            diff_obj = None
+        version = 1
+        table_name = None
+        diff_vals = (version, None, None)
+        ######Diff#######
+        crawl_list = self.floodfire_storage.get_crawllist(source_id, page_diff, diff_obj)
 
         # log 起始訊息
         start_msg = 'Start crawling ' + str(len(crawl_list)) + ' ' + self.code_name + '-news lists.'
@@ -171,9 +181,31 @@ class CntPageCrawler(BasePageCrawler):
                     news_page['image'] = len([v for v in news_page['visual_contents'] if v['type']==1])
                     news_page['video'] = len([v for v in news_page['visual_contents'] if v['type']==2])
 
-                    if self.floodfire_storage.insert_page(news_page):
+                   ######Diff#######
+                    if page_diff:
+                        last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
+                                                                                     news_page['publish_time'],
+                                                                                     diff_obj.compared_cols)
+                        if last_page != None:
+                            diff_col_list = diff_obj.page_diff(news_page, last_page)
+                            if diff_col_list is None:
+                                # 有上一筆，但沒有不同，更新爬抓次數，不儲存
+                                print('has last, no diff')
+                                crawl_count += 1 
+                                self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                                continue
+                            else:
+                                # 出現Diff，儲存
+                                version = last_page['version'] + 1
+                                last_page_id = last_page['id']
+                                diff_cols = ','.join(diff_col_list)
+                                diff_vals = (version, last_page_id, diff_cols)
+                    ######Diff#######
+                    print(diff_vals)
+                    if self.floodfire_storage.insert_page(news_page, table_name, diff_vals):
                         # 更新爬抓次數記錄
                         self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                        self.floodfire_storage.update_list_versioncount(row['url_md5'])
                         # 本次爬抓計數+1
                         crawl_count += 1
                     else:
@@ -185,7 +217,7 @@ class CntPageCrawler(BasePageCrawler):
                         for vistual_row in news_page['visual_contents']:
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
-                            self.floodfire_storage.insert_visual_link(vistual_row)
+                            self.floodfire_storage.insert_visual_link(vistual_row, version)
                     
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))

--- a/floodfire_crawler/engine/ett_page_crawler.py
+++ b/floodfire_crawler/engine/ett_page_crawler.py
@@ -9,6 +9,7 @@ from time import sleep, strftime, strptime
 from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+from floodfire_crawler.service.diff import FloodfireDiff
 
 class EttPageCrawler(BasePageCrawler):
 
@@ -163,7 +164,16 @@ class EttPageCrawler(BasePageCrawler):
         """
         # crawl_category = ['news', 'ent', 'ec', 'sports']
         source_id = self.floodfire_storage.get_source_id(self.code_name)
-        crawl_list = self.floodfire_storage.get_crawllist(source_id)
+        ######Diff#######
+        if page_diff:
+            diff_obj = FloodfireDiff()
+        else:
+            diff_obj = None
+        version = 1
+        table_name = None
+        diff_vals = (version, None, None)
+        ######Diff#######
+        crawl_list = self.floodfire_storage.get_crawllist(source_id, page_diff, diff_obj)
         # log 起始訊息
         start_msg = 'Start crawling ' + str(len(crawl_list)) + ' ' + self.code_name + '-news lists.'
         if page_raw:
@@ -196,9 +206,31 @@ class EttPageCrawler(BasePageCrawler):
                     news_page['url_md5'] = row['url_md5']
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
-                    if self.floodfire_storage.insert_page(news_page):
+                    ######Diff#######
+                    if page_diff:
+                        last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
+                                                                                     news_page['publish_time'],
+                                                                                     diff_obj.compared_cols)
+                        if last_page != None:
+                            diff_col_list = diff_obj.page_diff(news_page, last_page)
+                            if diff_col_list is None:
+                                # 有上一筆，但沒有不同，更新爬抓次數，不儲存
+                                print('has last, no diff')
+                                crawl_count += 1 
+                                self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                                continue
+                            else:
+                                # 出現Diff，儲存
+                                version = last_page['version'] + 1
+                                last_page_id = last_page['id']
+                                diff_cols = ','.join(diff_col_list)
+                                diff_vals = (version, last_page_id, diff_cols)
+                    ######Diff#######
+                    print(diff_vals)
+                    if self.floodfire_storage.insert_page(news_page, table_name, diff_vals):
                         # 更新爬抓次數記錄
                         self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                        self.floodfire_storage.update_list_versioncount(row['url_md5'])
                         # 本次爬抓計數+1
                         crawl_count += 1
                     else:
@@ -210,7 +242,7 @@ class EttPageCrawler(BasePageCrawler):
                         for vistual_row in news_page['visual_contents']:
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
-                            self.floodfire_storage.insert_visual_link(vistual_row)
+                            self.floodfire_storage.insert_visual_link(vistual_row, version)
                     
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))

--- a/floodfire_crawler/engine/ltn_page_crawler.py
+++ b/floodfire_crawler/engine/ltn_page_crawler.py
@@ -9,6 +9,7 @@ from time import sleep, strftime, strptime
 from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+from floodfire_crawler.service.diff import FloodfireDiff
 
 class LtnPageCrawler(BasePageCrawler):
 
@@ -567,7 +568,16 @@ class LtnPageCrawler(BasePageCrawler):
         程式進入點
         """
         source_id = self.floodfire_storage.get_source_id(self.code_name)
-        crawl_list = self.floodfire_storage.get_crawllist(source_id)
+        ######Diff#######
+        if page_diff:
+            diff_obj = FloodfireDiff()
+        else:
+            diff_obj = None
+        version = 1
+        table_name = None
+        diff_vals = (version, None, None)
+        ######Diff#######
+        crawl_list = self.floodfire_storage.get_crawllist(source_id, page_diff, diff_obj)
         # log 起始訊息
         start_msg = 'Start crawling ' + str(len(crawl_list)) + ' ' + self.code_name + '-news lists.'
         if page_raw:
@@ -601,12 +611,35 @@ class LtnPageCrawler(BasePageCrawler):
                     news_page['url_md5'] = row['url_md5']
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
-                    news_page['image'] = (len(news_page['visual_contents']) > 0)
+                    news_page['image'] = len(news_page['visual_contents'])
                     news_page['video'] = 0
+                    news_page['publish_time'] = re.sub('[ ]+', ' ', news_page['publish_time'])
 
-                    if self.floodfire_storage.insert_page(news_page):
+                    ######Diff#######
+                    if page_diff:
+                        last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
+                                                                                     news_page['publish_time'],
+                                                                                     diff_obj.compared_cols)
+                        if last_page != None:
+                            diff_col_list = diff_obj.page_diff(news_page, last_page)
+                            if diff_col_list is None:
+                                # 有上一筆，但沒有不同，更新爬抓次數，不儲存
+                                print('has last, no diff')
+                                crawl_count += 1 
+                                self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                                continue
+                            else:
+                                # 出現Diff，儲存
+                                version = last_page['version'] + 1
+                                last_page_id = last_page['id']
+                                diff_cols = ','.join(diff_col_list)
+                                diff_vals = (version, last_page_id, diff_cols)
+                    ######Diff#######
+                    print(diff_vals)
+                    if self.floodfire_storage.insert_page(news_page, table_name, diff_vals):
                         # 更新爬抓次數記錄
                         self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                        self.floodfire_storage.update_list_versioncount(row['url_md5'])
                         # 本次爬抓計數+1
                         crawl_count += 1
                     else:
@@ -618,7 +651,7 @@ class LtnPageCrawler(BasePageCrawler):
                         for vistual_row in news_page['visual_contents']:
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
-                            self.floodfire_storage.insert_visual_link(vistual_row)
+                            self.floodfire_storage.insert_visual_link(vistual_row, version)
                     
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))

--- a/floodfire_crawler/engine/ntk_page_crawler.py
+++ b/floodfire_crawler/engine/ntk_page_crawler.py
@@ -9,6 +9,7 @@ from time import sleep, strftime, strptime
 from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
+from floodfire_crawler.service.diff import FloodfireDiff
 
 
 class NtkPageCrawler(BasePageCrawler):
@@ -118,7 +119,16 @@ class NtkPageCrawler(BasePageCrawler):
         程式進入點
         """
         source_id = self.floodfire_storage.get_source_id(self.code_name)
-        crawl_list = self.floodfire_storage.get_crawllist(source_id)
+        ######Diff#######
+        if page_diff:
+            diff_obj = FloodfireDiff()
+        else:
+            diff_obj = None
+        version = 1
+        table_name = None
+        diff_vals = (version, None, None)
+        ######Diff#######
+        crawl_list = self.floodfire_storage.get_crawllist(source_id, page_diff, diff_obj)
         # log 起始訊息
         start_msg = 'Start crawling ' + \
             str(len(crawl_list)) + ' ' + self.code_name + '-news lists.'
@@ -153,10 +163,31 @@ class NtkPageCrawler(BasePageCrawler):
                     news_page['url_md5'] = row['url_md5']
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
-                    if self.floodfire_storage.insert_page(news_page):
+                    ######Diff#######
+                    if page_diff:
+                        last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
+                                                                                     news_page['publish_time'],
+                                                                                     diff_obj.compared_cols)
+                        if last_page != None:
+                            diff_col_list = diff_obj.page_diff(news_page, last_page)
+                            if diff_col_list is None:
+                                # 有上一筆，但沒有不同，更新爬抓次數，不儲存
+                                print('has last, no diff')
+                                crawl_count += 1 
+                                self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                                continue
+                            else:
+                                # 出現Diff，儲存
+                                version = last_page['version'] + 1
+                                last_page_id = last_page['id']
+                                diff_cols = ','.join(diff_col_list)
+                                diff_vals = (version, last_page_id, diff_cols)
+                    ######Diff#######
+                    print(diff_vals)
+                    if self.floodfire_storage.insert_page(news_page, table_name, diff_vals):
                         # 更新爬抓次數記錄
-                        self.floodfire_storage.update_list_crawlercount(
-                            row['url_md5'])
+                        self.floodfire_storage.update_list_crawlercount(row['url_md5'])
+                        self.floodfire_storage.update_list_versioncount(row['url_md5'])                            
                         # 本次爬抓計數+1
                         crawl_count += 1
                     else:
@@ -169,7 +200,7 @@ class NtkPageCrawler(BasePageCrawler):
                         for vistual_row in news_page['visual_contents']:
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
-                            self.floodfire_storage.insert_visual_link(vistual_row)
+                            self.floodfire_storage.insert_visual_link(vistual_row, version)
 
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))


### PR DESCRIPTION
新增中央社、中時電子報、ETtoday、自由時報、新頭殼、聯合新聞網的Diff機制
自由時報的日期會空白兩格，用re去除，且之前圖片數量變為True/False值，一並修正
聯合新聞網的日期沒有秒數，會造成比較錯誤，因此用datetime作轉換