### PR TITLE
AppleDaily fetch data via API endpoint

### DIFF
--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -10,6 +10,7 @@ from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
 
+
 class ApdPageCrawler(BasePageCrawler):
 
     def __init__(self, config, logme):
@@ -19,18 +20,20 @@ class ApdPageCrawler(BasePageCrawler):
 
     def fetch_html(self, url):
         """
-        取出網頁 HTML 原始碼
+        取得網頁 Json 格式文章資料
         Keyword arguments:
             url (string) -- 抓取的網頁網址
         """
         try:
             headers = {
-                'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36',
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36',
             }
+            # 將原文章網址換成該篇文章的 API endpoint
+            url = self.transform(url)
             response = requests.get(url, headers=headers, timeout=15)
             resp_content = {
-                'redirected_url': response.url, # 取得最後 redirect 之後的真實網址
-                'html': response.text
+                'redirected_url': response.url,  # 取得最後 redirect 之後的真實網址
+                'json': response.json()
             }
         except requests.exceptions.HTTPError as err:
             msg = "HTTP exception error: {}".format(err.args[1])
@@ -42,99 +45,85 @@ class ApdPageCrawler(BasePageCrawler):
             return 0, msg
 
         return response.status_code, resp_content
-        
-    def fetch_news_content(self, soup):
-        #延伸閱讀的前綴語句
-        tail_list = ['看了這則新聞的人','想知道更多']
-        fake_img_list = ['//img.appledaily.com.tw/images/NextDigital/logo_NextMedia_m.png']
-        
-        page = {}
-        for br in soup.find_all("br"):
-            br.replace_with("\n")
-        
+
+    def fetch_news_content(self, res_json):
+        report = {}
         # --- 取出標題 ---
-        page['title'] = soup.hgroup.h1.text.strip().replace("　", " ").replace("\u200b","")
+        report['title'] = res_json['content_elements'][0]['headlines']['basic']
 
         # --- 取出內文 ---
-        content = soup.select('div p')[0].text.replace("　"," ").replace("\u200b","")
-        tails = [content.find(a_tail) for a_tail in tail_list if content.find(a_tail)>0]
-        news_content = content if len(tails)==0 else content[0:min(tails)]
-        page['body'] = news_content
+        article = [d['content'] for d in res_json['content_elements'][0]['content_elements'] if d['type'] == 'raw_html'][0].replace("<br>", "\n").replace("<br />", "\n")
+        soup = BeautifulSoup(article, 'lxml')
+        report['article'] = soup.get_text()
+
+        # --- 取出記者 ---
+        # (XXX/XX報導) (曾珮瑛、張世瑜/高雄報導) https://regex101.com/r/DvppFX/1
+        author = re.search(r'[(（](.*?中心)?(.*?)(／|\/|╱)(.*?)報導[）)]', report['article'])
+        if author is not None:
+            report['authour'] = [author.group(2)]
+        else:
+            report['authour'] = ['Cannot find in report']
 
         # --- 取出發布時間 ---
-        page['publish_time'] = self.fetch_publish_time(soup)
-        
+        report['publish_time'] = self.fetch_publish_time(res_json['content_elements'][0]['last_updated_date'])
+
         # --- 取出關鍵字 ---
-        #keywords
-        keys = [x.text for x in soup.select('h3 a')]
-        page['keywords'] = keys
-        
-        # --- 取出記者 ---
-        #authors
-        brackets = re.findall('(?:（|\()(.*?)(?:）|\))', news_content)
-        split_publishers = re.findall("\w+",(', '.join([bracket for bracket in brackets if bracket.find("報導") > 0])))
-        publishers = list(sorted(set([x for x in split_publishers if len(re.findall("報導",x))==0])))
-        page['authors'] = publishers
-        
+        report['keyword'] = [tag['text'] for tag in res_json['content_elements'][0]['taxonomy']['tags']]
+
         # --- 取出圖片數 ---
-        #has_image
-        cover_img = soup.findAll('div',{'class':'ndAritcle_headPic'})
-        foot_img = [y for y in [x for x in soup.select('figure') if x.img] if y.img['src'] not in fake_img_list]
-        page['image'] = (len(foot_img) + len(cover_img))
+        image = [d for d in res_json['content_elements'][0]['content_elements'] if d['type'] == 'image']
+        report['image'] = len(image)
 
+        report['visual_contents'] = list()
         # -- 取出視覺資料連結（圖片） ---
-        page['visual_contents'] = list()
-        imgs = cover_img + foot_img
-        for img in imgs:
-            page['visual_contents'].append({
-                    'type': 1,
-                    'visual_src': img.img['src'],
-                    'caption': img.text
-                })
+        report['visual_contents'] = [{
+            'type': 1,
+            'visual_src': i['url'],
+            'caption': i['caption']
+        } for i in image]
 
-        # --- 取出影片數 ---
-        #has_video        
-        has_video = 1 if soup.find('div',{'id':'videobox'}) else 0
-        page['video'] = has_video
-        
-        # -- 取出視覺資料連結（影片） ---
-        if(has_video>0):
-            video_box = soup.find('div',{'id':'videobox'})
-            video_url = re.findall('https?://(?:[-\w./])+.(?:mp4)', video_box.select('script')[-1].text)[0]
-            page['visual_contents'].append({
+        video = res_json['content_elements'][0]['promo_items']['basic']
+        if video['type'] == 'video':
+            report['video'] = 1
+            # -- 取出視覺資料連結（影片） ---
+            report['visual_contents'].append({
                 'type': 2,
-                'visual_src': video_url,
-                'caption': ''
+                'visual_src': video['streams'][0]['url'],
+                'caption': 'video_id:' + video['additional_properties']['video_id']
             })
+        else:
+            report['video'] = 0
 
-        """
-        #可以擷取影片網址以及影片截圖
-        video_box = soup.find('div',{'id':'videobox'})
+            return report
 
-        re.findall('https?://(?:[-\w./])+.(?:mp4)', video_box.select('script')[-1].text)[0]
-        
-        re.findall('https?://(?:[-\w./])+.(?:jpg|gif|png)', video_box.select('script')[-1].text)[0]
-
-        """
-        return page   
-    
-    def fetch_publish_time(self, soup):
-        time = soup.select('.ndArticle_creat')[0].text.strip()
-        news_time = strftime('%Y-%m-%d %H:%M:%S', strptime(time[time.find('：')+1:], '%Y/%m/%d %H:%M'))
+    def fetch_publish_time(self, timeString):
+        # timeString e.g 2019-12-24T13:03:18.419Z
+        news_time = strftime('%Y-%m-%d %H:%M:%S', strptime(timeString, '%Y-%m-%dT%H:%M:%S.%fZ'))
         return(news_time)
-    
-    def compress_html(self, page_html):
-        """
-        壓縮原始的 HTML
 
-        Keyword arguments:
-            page_html (string) -- 原始 html
+    def transform(self, inUrl):
+
+        outUrl = None
+        test = re.search(r'\/(\d{7})\/', inUrl)
+        if(test != None):
+            mId = test.group(1)
+            outUrl = 'https://tw.appledaily.com/pf/api/v3/content/fetch/content-by-motherlode-id?query=%7B%22id%22%3A%221_{mId}%22%2C%22website_url%22%3A%22tw-appledaily%22%7D&d=35&_website=tw-appledaily'.format(
+                mId=mId)
+
+        t = re.search(r'\/([[:upper:],0-9]{26})\/', inUrl)
+        if(t != None):
+            Id = t.group(1)
+            outUrl = 'https://tw.appledaily.com/pf/api/v3/content/fetch/content-by-id?query=%7B%22id%22%3A%22{id}%22%2C%22published%22%3Atrue%2C%22website_url%22%3A%22tw-appledaily%22%7D&_website=tw-appledaily'.format(
+                id=Id)
+        return outUrl
+
+    def compress_html(self, page_json):
         """
-        # minhtml = re.sub('>\s*<', '><', page_html, 0, re.M)
-        minhtml = htmlmin.minify(page_html, remove_empty_space=True)
-        return minhtml
-    
-    def run(self, page_raw=False, page_diff=False, page_visual = False):
+        Deprecated in this news source
+        """
+        return page_json
+
+    def run(self, page_raw=False, page_diff=False, page_visual=False):
         """
         程式進入點
         """
@@ -162,21 +151,22 @@ class ApdPageCrawler(BasePageCrawler):
                         news_page_raw['list_id'] = row['id']
                         news_page_raw['url'] = row['url']
                         news_page_raw['url_md5'] = row['url_md5']
-                        news_page_raw['page_content'] =  self.compress_html(html_content['html'])
+                        news_page_raw['page_content'] = html_content['json']
                         self.floodfire_storage.insert_page_raw(news_page_raw)
                         print('Save ' + str(row['id']) + ' page Raw.')
 
-                    soup = BeautifulSoup(html_content['html'], 'html.parser')
-                    if(soup.contents[0]!='html'):
+                    # soup = BeautifulSoup(html_content['html'], 'html.parser')
+                    resjson = html_content['json']
+                    if(len(resjson['content_elements']) == 0):
                         self.floodfire_storage.update_list_errorcount(row['url_md5'])
                         continue
-                    news_page = self.fetch_news_content(soup)
+                    news_page = self.fetch_news_content(resjson)
                     news_page['list_id'] = row['id']
                     news_page['url'] = row['url']
                     news_page['url_md5'] = row['url_md5']
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
-                    
+
                     if self.floodfire_storage.insert_page(news_page):
                         # 更新爬抓次數記錄
                         self.floodfire_storage.update_list_crawlercount(row['url_md5'])
@@ -192,7 +182,7 @@ class ApdPageCrawler(BasePageCrawler):
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
                             self.floodfire_storage.insert_visual_link(vistual_row)
-                    
+
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))
                 else:

--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -96,7 +96,7 @@ class ApdPageCrawler(BasePageCrawler):
         else:
             report['video'] = 0
 
-            return report
+        return report
 
     def fetch_publish_time(self, timeString):
         # timeString e.g 2019-12-24T13:03:18.419Z

--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -3,6 +3,7 @@
 import requests
 import re
 import htmlmin
+import json
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
 from time import sleep, strftime, strptime
@@ -161,7 +162,7 @@ class ApdPageCrawler(BasePageCrawler):
                         news_page_raw['list_id'] = row['id']
                         news_page_raw['url'] = row['url']
                         news_page_raw['url_md5'] = row['url_md5']
-                        news_page_raw['page_content'] = html_content['json']
+                        news_page_raw['page_content'] = json.dumps(html_content['json'])
                         self.floodfire_storage.insert_page_raw(news_page_raw)
                         print('Save ' + str(row['id']) + ' page Raw.')
 
@@ -176,7 +177,7 @@ class ApdPageCrawler(BasePageCrawler):
                     news_page['url_md5'] = row['url_md5']
                     news_page['redirected_url'] = html_content['redirected_url']
                     news_page['source_id'] = source_id
-                    
+
                     ######Diff#######
                     if page_diff:
                         last_page, table_name = self.floodfire_storage.get_last_page(news_page['url_md5'],
@@ -187,7 +188,7 @@ class ApdPageCrawler(BasePageCrawler):
                             if diff_col_list is None:
                                 # 有上一筆，但沒有不同，更新爬抓次數，不儲存
                                 print('has last, no diff')
-                                crawl_count += 1 
+                                crawl_count += 1
                                 self.floodfire_storage.update_list_crawlercount(row['url_md5'])
                                 continue
                             else:
@@ -214,7 +215,7 @@ class ApdPageCrawler(BasePageCrawler):
                             vistual_row['list_id'] = row['id']
                             vistual_row['url_md5'] = row['url_md5']
                             self.floodfire_storage.insert_visual_link(vistual_row, version)
-                    
+
                     # 隨機睡 2~6 秒再進入下一筆抓取
                     sleep(randint(2, 6))
                 else:


### PR DESCRIPTION
# Origin Note
http://note.floodfire.tw/PrIeYsB5SDeEtXjioHsDuw?both

## Test Code
https://repl.it/@et84121/appledailyPa-Chong

### Note

* 似乎是 python 並不是 thread-Safe 的關系，在測試程式裡的 thread 數目如果太高的話會造成 jsonDecodeError
* 還有一些文章以API擷取資料時會失敗

## 蘋果日報 API

### List API
https://tw.news.appledaily.com/articleajax/realtime/

記錄一下  這是蘋果日報的 API
可以取得即時新聞的清單
https://tw.news.appledaily.com/articleajax/realtime/international/3

另一個有效例子是這個
international  是國際新聞的分類名稱
3 是指頁數



### 文章 API

#### content-by-id
可以直接查到整篇文章的資料

https://tw.lifestyle.appledaily.com/pf/api/v3/content/fetch/content-by-id/

參數

``` 
query:
{"id":"SLY6AJSWTXDBUA7SQJT2OARKAQ","published":true,"website_url":"tw-appledaily"}
filter:
{canonical_url,credits{by{name,slug,url}},description{basic},headlines{basic},last_updated_date,promo_items{basic{additional_properties{focal_point},alt_text,height,promo_image{url},type,url,width},lead_video{type,url}},publish_date,subheadlines{basic},taxonomy{primary_section{_id,path}},website_url,websites{tw-appledaily{website_section{_id,name},website_url}}}
d:35
_website:tw-appledaily
```

試了一下 `filter`是用來決定不需要哪些資料的
所以不要這個參數就拿到全部的文章內容了

`id`就是文章網址最後一個
 `https://tw.lifestyle.appledaily.com/supplement/20191210/WVSRMYMTYZQLYVWEQ6SQQWVRPA/   `

`d`猜不到是啥  取消了好像也沒差

`website`似乎是因為有香港跟台灣兩區

#### content-by-motherlode-id
這個是用另一個稱為 motherlode-id 的 id 來取得文章之端點
   
https://tw.lifestyle.appledaily.com/pf/api/v3/content/fetch/content-by-motherlode-id   

參數組合
```
query:{"id":"1_1681173","website_url":"tw-appledaily"}
d:35
_website:tw-appledaily
```


測試網址
 `https://tw.news.appledaily.com/international/realtime/20191223/1681173/   `
最後一個數字就是蘋果日報的 motherlode-id

前端還沒有改版的分類新聞在網址上都以 motherlode-id 出現
然後我也測過用API也可以取得那些文章


## Note
* 蘋果日報直接爬取會遇上 payWall 問題
* 蘋果日報的服務搬到AWS上了
* 它們前端頁面改版中，目前某些特定分類採用 react.js 做為其前端框架 2019/12/24
* API裡有 revision 的記綠，也許diff機制會需要這份資料
* 蘋果有防DOS 大量存取API()的話會被Ban IP
