### PR TITLE
自由時報體育版時間用/而非-

### DIFF
--- a/floodfire_crawler/engine/ltn_page_crawler.py
+++ b/floodfire_crawler/engine/ltn_page_crawler.py
@@ -611,6 +611,7 @@ class LtnPageCrawler(BasePageCrawler):
                     news_page['image'] = len(news_page['visual_contents'])
                     news_page['video'] = 0
                     news_page['publish_time'] = re.sub('[ ]+', ' ', news_page['publish_time'])
+                    news_page['publish_time'] = news_page['publish_time'].replace('/', '-')
                     news_page['publish_time'] = news_page['publish_time'][:19]
 
                     ######Diff#######


### PR DESCRIPTION
修正自由時報只有體育版是用2020/01/01而非 2020-01-01，因此造成的解析錯誤