### PR TITLE
修改蘋果日報取得List列表，限定Story，修正Page影片Id以及作者欄位

### DIFF
--- a/floodfire_crawler/engine/apd_list_crawler.py
+++ b/floodfire_crawler/engine/apd_list_crawler.py
@@ -57,7 +57,10 @@ class ApdListCrawler(BaseListCrawler):
         res = requests.get(base_url)
         d_value = re.findall('\?d=[0-9]+', res.text)[0].split('=')[1]
 
-        url = 'https://tw.appledaily.com/pf/api/v3/content/fetch/query-feed?query=%7B%22feedOffset%22%3A0%2C%22feedQuery%22%3A%22%22%2C%22feedSize%22%3A%22100%22%2C%22sort%22%3A%22display_date%3Adesc%22%7D&d='+d_value+'&_website=tw-appledaily'
+        url = 'https://tw.appledaily.com/pf/api/v3/content/fetch/query-feed?' + \
+              'query={"feedOffset":0,"feedQuery":"type:story","feedSize":"100","sort":"display_date:desc"}&'+\
+              'd='+d_value+'&_website=tw-appledaily'
+              
         html = self.fetch_html(url)
         json_soup = json.loads(html)
         consecutive = 0

--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -63,9 +63,13 @@ class ApdPageCrawler(BasePageCrawler):
         # (XXX/XX報導) (曾珮瑛、張世瑜/高雄報導) https://regex101.com/r/DvppFX/1
         author = re.search(r'[(（](.*?中心)?(.*?)(／|\/|╱)(.*?)報導[）)]', report['body'])
         if author is not None:
-            report['authors'] = [author.group(2)]
+            author_str = author.group(2)
         else:
-            report['authors'] = ['Cannot find in report']
+            author_str = ''
+        left_bracket_pos = max(author_str.rfind('('), author_str.rfind('（'))
+        if (left_bracket_pos > 0):
+            author_str = author_str[(left_bracket_pos+1):]
+        report['authors'] = author_str.split('、')
 
         # --- 取出發布時間 ---
         report['publish_time'] = self.fetch_publish_time(res_json['last_updated_date'])
@@ -96,7 +100,7 @@ class ApdPageCrawler(BasePageCrawler):
             report['visual_contents'].append({
                 'type': 2,
                 'visual_src': video['streams'][0]['url'],
-                'caption': 'video_id:' + video['additional_properties']['video_id']
+                'caption': 'video_id:' + video['additional_properties']['videoId']
             })
         else:
             report['video'] = 0
@@ -113,8 +117,8 @@ class ApdPageCrawler(BasePageCrawler):
 
     def transform(self, inUrl):
         Id = inUrl.split('/')[-2]
-        outUrl = 'https://tw.appledaily.com/pf/api/v3/content/fetch/content-by-id?query=%7B%22id%22%3A%22{id}%22%2C%22published%22%3Atrue%2C%22website_url%22%3A%22tw-appledaily%22%7D'.format(
-            id=Id)
+        outUrl = 'https://tw.appledaily.com/pf/api/v3/content/fetch/content-by-id/' +\
+                 '{"id":"'+Id+'","published":true,"website_url":"tw-appledaily"}'
         return outUrl
 
     def compress_html(self, page_json):


### PR DESCRIPTION
修改蘋果日報List列表，原本會爬到影片之類的內容，現在限定為Story
Page的影片Id由 _id改為Id，修改
修改作者欄位，擷取到最後一個左括號位置，並且將多個人名分段