### PR TITLE
一月例行檢修：蘋果日報、中時電子報、中央社、聯合新聞網

### DIFF
--- a/floodfire_crawler/engine/apd_page_crawler.py
+++ b/floodfire_crawler/engine/apd_page_crawler.py
@@ -86,10 +86,10 @@ class ApdPageCrawler(BasePageCrawler):
         report['visual_contents'] = [{
             'type': 1,
             'visual_src': i['url'],
-            'caption': i['caption']
+            'caption': i['caption'] if 'caption'  in i else '',
         } for i in image]
 
-        if len(res_json['promo_items']) == 0:
+        if 'promo_items' not in res_json or len(res_json['promo_items']) == 0:
             report['video'] = 0
             return report
 

--- a/floodfire_crawler/engine/cna_page_crawler.py
+++ b/floodfire_crawler/engine/cna_page_crawler.py
@@ -84,14 +84,6 @@ class CnaPageCrawler(BasePageCrawler):
                     if author_in_parenthesis[i] not in get_author:
                         get_author.append(author_in_parenthesis[i])
 
-#            name = first_line_author[1][:3].replace('、','')
-#            get_author.append(first_line_author[1][:3])
-#        if len(author_in_parenthesis) >1:
-#            for i in range(1,len(author_in_parenthesis)):
-#                if i == len(author_in_parenthesis):
-#                    get_author.append(author_in_parenthesis[i])
-#                else:
-#                    get_author.append(author_in_parenthesis[i][:3])
         for i in range(len(get_in_parenthesis)):
             if '譯者：' in get_in_parenthesis[i]:
                 author_list = get_in_parenthesis[i].split('/')
@@ -123,10 +115,14 @@ class CnaPageCrawler(BasePageCrawler):
         page['visual_contents'] = list()
         for i in range(len(image_list)):
             img_content = image_list[i].find('img')
+            if image_list[i].find('div',class_='picinfo') is not None:
+                caption = image_list[i].find('div',class_='picinfo').text
+            else:
+                caption = ''
             page['visual_contents'].append({
                     'type': 1,
                     'visual_src': img_content['data-src'] if 'data-src' in str(img_content) else img_content['src'],
-                    'caption': image_list[i].find('div',class_='picinfo').text
+                    'caption': caption
                 })
 
         # --- 取出影片數 ---

--- a/floodfire_crawler/engine/cnt_page_crawler.py
+++ b/floodfire_crawler/engine/cnt_page_crawler.py
@@ -58,7 +58,14 @@ class CntPageCrawler(BasePageCrawler):
         page['title'] = soup.find('h1').text.strip()
         # --- 取出內文 ---
         article_content = soup.find('div', {'class', 'article-body'}).find_all('p')
-        page['body'] = "\n".join([x.text for x in article_content if x.text!=''])
+        regrex_pattern = re.compile(pattern = "["
+        "\U0001F600-\U0001F64F"  # emoticons
+        "\U0001F300-\U0001F5FF"  # symbols & pictographs
+        "\U0001F680-\U0001F6FF"  # transport & map symbols
+        "\U0001F1E0-\U0001F1FF"  # flags (iOS)
+                           "]+", flags = re.UNICODE)
+        content = "\n".join([x.text for x in article_content if x.text!=''])
+        page['body'] = regrex_pattern.sub('',content)
 
         # --- 取出發布時間 ---
         page['publish_time'] = self.fetch_publish_time(soup)


### PR DESCRIPTION
蘋果日報：
修正沒有敘述的圖片解析錯誤
修正API沒有內容影片位置為空時的解析錯誤
中時電子報：
文章解析未出錯，懷疑是儲存是發生問題，經觀察每一篇內文都含有Emoji，因此先將所有內文的Emoji移除
中央社：
修正沒有敘述的圖片解析錯誤
聯合新聞網：
疫情特別頁面
修正解析JS裡面的變數出現註解導致的文字解析錯誤