### PR TITLE
引入demoji套件作為移除emoji的方式：修改中央社、中時、聯合新聞網的內文爬抓

### DIFF
--- a/floodfire_crawler/engine/cna_page_crawler.py
+++ b/floodfire_crawler/engine/cna_page_crawler.py
@@ -10,6 +10,7 @@ from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
 from floodfire_crawler.service.diff import FloodfireDiff
+import demoji
 
 class CnaPageCrawler(BasePageCrawler):
 
@@ -17,6 +18,7 @@ class CnaPageCrawler(BasePageCrawler):
         self.code_name = "cna"
         self.floodfire_storage = FloodfireStorage(config)
         self.logme = logme
+        demoji.download_codes()
 
     def fetch_html(self, url):
         """
@@ -53,7 +55,7 @@ class CnaPageCrawler(BasePageCrawler):
 
         # --- 取出內文 ---
         content = all_article.find('div', class_='paragraph').text
-        page['body'] = content
+        page['body'] = demoji.replace(content, '')
 
         # --- 取出發布時間 ---
         page['publish_time'] = self.fetch_publish_time(all_article)

--- a/floodfire_crawler/engine/cnt_page_crawler.py
+++ b/floodfire_crawler/engine/cnt_page_crawler.py
@@ -10,6 +10,7 @@ from random import randint
 from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
 from floodfire_crawler.service.diff import FloodfireDiff
+import demoji
 
 class CntPageCrawler(BasePageCrawler):
     
@@ -18,6 +19,7 @@ class CntPageCrawler(BasePageCrawler):
         self.regex_pattern = re.compile(r"var yID = \'(\w.*)\';")
         self.floodfire_storage = FloodfireStorage(config)
         self.logme = logme
+        demoji.download_codes()
     
     def fetch_html(self, url):
         """
@@ -58,14 +60,8 @@ class CntPageCrawler(BasePageCrawler):
         page['title'] = soup.find('h1').text.strip()
         # --- 取出內文 ---
         article_content = soup.find('div', {'class', 'article-body'}).find_all('p')
-        regrex_pattern = re.compile(pattern = "["
-        "\U0001F600-\U0001F64F"  # emoticons
-        "\U0001F300-\U0001F5FF"  # symbols & pictographs
-        "\U0001F680-\U0001F6FF"  # transport & map symbols
-        "\U0001F1E0-\U0001F1FF"  # flags (iOS)
-                           "]+", flags = re.UNICODE)
         content = "\n".join([x.text for x in article_content if x.text!=''])
-        page['body'] = regrex_pattern.sub('',content)
+        page['body'] = demoji.replace(content, '')
 
         # --- 取出發布時間 ---
         page['publish_time'] = self.fetch_publish_time(soup)

--- a/floodfire_crawler/engine/udn_page_crawler.py
+++ b/floodfire_crawler/engine/udn_page_crawler.py
@@ -12,6 +12,7 @@ from floodfire_crawler.core.base_page_crawler import BasePageCrawler
 from floodfire_crawler.storage.rdb_storage import FloodfireStorage
 from floodfire_crawler.service.diff import FloodfireDiff
 import json
+import demoji
 
 class UdnPageCrawler(BasePageCrawler):
 
@@ -19,6 +20,7 @@ class UdnPageCrawler(BasePageCrawler):
         self.code_name = "udn"
         self.floodfire_storage = FloodfireStorage(config)
         self.logme = logme
+        demoji.download_codes()
 
     def fetch_html(self, url):
         """
@@ -151,7 +153,8 @@ class UdnPageCrawler(BasePageCrawler):
         # 如果有轉址
         content_area = soup.find_all('p')
         if 'window.location.href' in content_area[0].text:
-            page['body'] = content_area[0].text
+            content = content_area[0].text
+            page['body'] = demoji.replace(content, '')
         else:
             contents = [x.text for x in content_area if x.text != '' and x.text!=' ' and x.text!='\n' and x.p is None and x.script is None]
             # 如果內文只有一張圖
@@ -160,7 +163,8 @@ class UdnPageCrawler(BasePageCrawler):
                 return page
             if(contents[0][0]==' '):
                 contents[0] = contents[0][1:]
-            page['body'] = ('\n').join(contents)
+            content = ('\n').join(contents)
+            page['body'] = demoji.replace(content, '')
 
         return page   
 


### PR DESCRIPTION
引入demoji套件，讓程式在執行時下載最新的emoji檔
並於中央社、中時、聯合新聞網的內文中，移除跟所有符合的emoji符號