### PR TITLE
修正中央社日期修改會影響字串解析的問題

### DIFF
--- a/floodfire_crawler/engine/cna_page_crawler.py
+++ b/floodfire_crawler/engine/cna_page_crawler.py
@@ -183,6 +183,7 @@ class CnaPageCrawler(BasePageCrawler):
     
     def fetch_publish_time(self, soup):
         time = soup.find('div', class_='updatetime').text.strip()
+        time = time.split('（')[0]
         news_time = strftime('%Y-%m-%d %H:%M:%S', strptime(time[time.find('：')+1:], '%Y/%m/%d %H:%M'))
         return(news_time)
     


### PR DESCRIPTION
中央社日期修改現在帶在原本日期後面，造成解析錯誤
因此將日期切分後，重新解析